### PR TITLE
config: disable autohintOTF

### DIFF
--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -1,4 +1,4 @@
 sources:
   - Agbalumo.glyphspackage
-
 familyName: Agbalumo
+autohintOTF: false


### PR DESCRIPTION
Disable autohintOTF to avoid `ERROR: Font has neither StemSnapV nor StdVW!`.

```
[8/9] otfautohint ../fonts/otf/Agbalumo-Regular...../fonts/otf/Agbalumo-Regular.otf.autohintstamp
FAILED: ../fonts/otf/Agbalumo-Regular.otf.autohintstamp
otfautohint ../fonts/otf/Agbalumo-Regular.otf && touch ../fonts/otf/Agbalumo-Regular.otf.autohintstamp
ERROR: Font has neither StemSnapV nor StdVW!
```